### PR TITLE
Fix SHA256 to actual value; Increment revision;

### DIFF
--- a/Formula/rtmp-nginx-module.rb
+++ b/Formula/rtmp-nginx-module.rb
@@ -4,11 +4,11 @@ class RtmpNginxModule < Formula
   url "https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/archive/v1.1.7.10.tar.gz"
   sha256 "0b32d34704d038485d93656dc43e970bbdd9c63bca7ff3b81ad941cde9144fc6"
   version "1.1.7.11-dev"
-  revision 1
+  revision 2
   
   patch do
     url "https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/compare/v1.1.7.10...d25c56f.diff"
-    sha256 "621d406f20195400603f492ec785ea1c01af04e877bc84c1aeb40487d27dcc13"
+    sha256 "11991a7bedfb978813ef9f75cd05f8a2d74caed52d89683f8cdecce5515108cf"
   end
 
   bottle :unneeded


### PR DESCRIPTION
I suppose it should prevent from getting next error:
Error: SHA256 mismatch
Expected: 621d406f20195400603f492ec785ea1c01af04e877bc84c1aeb40487d27dcc13
Actual: 11991a7bedfb978813ef9f75cd05f8a2d74caed52d89683f8cdecce5515108cf
Archive: /Users/ivan/Library/Caches/Homebrew/rtmp-nginx-module--patch-621d406f20195400603f492ec785ea1c01af04e877bc84c1aeb40487d27dcc13.diff
To retry an incomplete download, remove the file above.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/denji/homebrew-nginx/blob/master/.github/CONTRIBUTING.md) document?
- [ ] Checked to ensure there aren't other open [Pull Requests](https://github.com/denji/homebrew-nginx/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [x] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
