### PR TITLE
Updated to latest version of nginx-mod_zip

### DIFF
--- a/Formula/mod-zip-nginx-module.rb
+++ b/Formula/mod-zip-nginx-module.rb
@@ -1,9 +1,9 @@
 class ModZipNginxModule < Formula
   desc "ZIP archiver for nginx"
   homepage "https://github.com/evanmiller/mod_zip"
-  url "https://github.com/evanmiller/mod_zip/archive/35ea7ff.tar.gz"
-  version "0.1"
-  sha256 "2198071ea1d25a861407745a0a99fffba6cc2784e9a79cabf5a6273f0ff478d1"
+  url "https://github.com/evanmiller/mod_zip/archive/255cf540ac53865df93e022bb8c20f1a1e9a54da.zip"
+  version "0.2"
+  sha256 "48f7803dfe6da9465a5101871ceee584402d055fe1e9c6ecff48cb20d4e9d836"
 
   bottle :unneeded
 


### PR DESCRIPTION
Updated to nginx-mod_zip, released 8 Oct 2017. 

Builds fine with nginx/1.12.2 on High Sierra 10.13.6.