### PR TITLE
Make references to openresty-ssl explicit

### DIFF
--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -22,8 +22,8 @@ class Openresty < Formula
 
   def install
     # Configure
-    cc_opt = "-I#{HOMEBREW_PREFIX}/include -I#{Formula["pcre"].opt_include} -I#{Formula["openresty-openssl"].opt_include}"
-    ld_opt = "-L#{HOMEBREW_PREFIX}/lib -L#{Formula["pcre"].opt_lib} -L#{Formula["openresty-openssl"].opt_lib}"
+    cc_opt = "-I#{HOMEBREW_PREFIX}/include -I#{Formula["pcre"].opt_include} -I#{Formula["denji/nginx/openresty-openssl"].opt_include}"
+    ld_opt = "-L#{HOMEBREW_PREFIX}/lib -L#{Formula["pcre"].opt_lib} -L#{Formula["denji/nginx/openresty-openssl"].opt_lib}"
 
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
Brew will stop installation due to ambiguous references. This fixed it for me.