### PR TITLE
lua-nginx-module 0.10.14

### DIFF
--- a/Formula/lua-nginx-module.rb
+++ b/Formula/lua-nginx-module.rb
@@ -1,8 +1,8 @@
 class LuaNginxModule < Formula
   desc "Embed the power of Lua into Nginx"
   homepage "https://github.com/openresty/lua-nginx-module"
-  url "https://github.com/openresty/lua-nginx-module/archive/v0.10.13.tar.gz"
-  sha256 "ecea8c3d7f69dd48c6132498ddefb5d83ba9f387fa3d4da14e2abeacdfc8a3ee"
+  url "https://github.com/openresty/lua-nginx-module/archive/v0.10.14.tar.gz"
+  sha256 "9e17e086d0ac74fb72326abb7f2f8274c080b4981cbf358b026307b4088e7148"
   head "https://github.com/openresty/lua-nginx-module.git"
 
   bottle :unneeded


### PR DESCRIPTION
Fixes a segfault when trying to use init_worker_by_lua in newer versions
of nginx.

I did not update to 0.10.15 since that now requires resty.core as a
dependency.

References:
 - https://github.com/openresty/lua-nginx-module/issues/1348
 - https://github.com/openresty/lua-nginx-module/pull/1352
 - https://github.com/openresty/lua-nginx-module/pull/1349

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/denji/homebrew-nginx/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/denji/homebrew-nginx/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?

```
wbond/nginx/lua-nginx-module:
  * C: 1: col 1: A `test do` test block should be added
Error: 1 problem in 1 formula detected
```

- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?

*There doesn't appear to be a `revision` in lua-nginx-module.*

- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?

*There doesn't appear to be a `revision` in lua-nginx-module.*

- [x] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?

*There don't appear to be any existing tests. I did, however, tap my fork and install nginx with the lua module and successfully run the configuration that uses `init_worker_by_lua` and nginx no longer segfaults.*