### PR TITLE
Add module: njs 0.3.9

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -83,6 +83,7 @@ class NginxFull < Formula
       "mruby" => "Build with MRuby support",
       "naxsi" => "Build with Naxsi support",
       "nchan" => "Build with Nchan support",
+      "njs" => "Build with njs support",
       "notice" => "Build with HTTP Notice support",
       "php-session" => "Build with Parse PHP Sessions support",
       "tarantool" => "Build with Tarantool upstream support",
@@ -267,9 +268,14 @@ class NginxFull < Formula
 
     # Third Party Modules
     self.class.third_party_modules.each_key do |name|
-      if build.with?("#{name}-module")
+      if build.with?("#{name}-module") and not name == "njs"
         args << "--add-module=#{HOMEBREW_PREFIX}/share/#{name}-nginx-module"
       end
+    end
+
+    # The njs module is special since it has a command-line component as well, we have to specify the nginx/ subpath
+    if build.with?("njs-module")
+      args << "--add-module=#{HOMEBREW_PREFIX}/share/njs-nginx-module/nginx"
     end
 
     # Passenger

--- a/Formula/njs-nginx-module.rb
+++ b/Formula/njs-nginx-module.rb
@@ -1,0 +1,27 @@
+class NjsNginxModule < Formula
+  desc "Adds support for njs scripting to nginx"
+  homepage "https://github.com/nginx/njs"
+  url "https://github.com/nginx/njs/archive/0.3.9.tar.gz"
+  sha256 "429f34c5e02a56dd6a8666aa3192288d8693c9cfcde8406390381fa85acf9b28"
+  head "https://github.com/nginx/njs.git"
+
+  bottle :unneeded
+
+  depends_on "pcre" => :build
+  depends_on "readline" => :build
+
+  def install
+    # First, configure and install the njs command-line binary
+    system "./configure"
+    system "make", "njs"
+    bin.install "build/njs"
+
+    # Then, copy the rest of the module code over to the share to be used by
+    # the `nginx-full` formula.
+    pkgshare.install Dir["*"]
+  end
+
+  test do
+    system "njs", "-v"
+  end
+end


### PR DESCRIPTION
This PR introduces support for the [njs module](https://nginx.org/en/docs/njs). This is my first time messing with Homebrew, and I used it on Fedora inside of a container...but it should still work. I intend on shipping it to developers on my team to easily enable this module on MacOS; so if anything doesn't work as expected this PR (or a subsequent PR) will address it.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/denji/homebrew-nginx/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/denji/homebrew-nginx/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [x] Written a sensible test? (The best test is to compile and run a sample program.)