### PR TITLE
upgrade rtmp module to v1.2.2-r1 no patch needed

### DIFF
--- a/Formula/rtmp-nginx-module.rb
+++ b/Formula/rtmp-nginx-module.rb
@@ -1,15 +1,10 @@
 class RtmpNginxModule < Formula
   desc "NGINX-based Media Streaming Server"
   homepage "https://github.com/sergey-dryabzhinsky/nginx-rtmp-module"
-  url "https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/archive/v1.1.7.10.tar.gz"
-  version "1.1.7.11-dev"
-  sha256 "0b32d34704d038485d93656dc43e970bbdd9c63bca7ff3b81ad941cde9144fc6"
+  url "https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/archive/v1.2.2-r1.tar.gz"
+  version "1.2.2-r1"
+  sha256 "60b1743bd4b3450880bcd28396ce7d416c04d17d213873a490177fc83bb12211"
   revision 3
-
-  patch do
-    url "https://github.com/sergey-dryabzhinsky/nginx-rtmp-module/compare/v1.1.7.10..504b9ee.diff"
-    sha256 "afa7a32135bc522383b1c1ad9d32284856b7b59113401a5ad00039da015f66e3"
-  end
 
   def install
     pkgshare.install Dir["*"]


### PR DESCRIPTION
I use that on an Apple Silicon mac, since there're no more patches needed it closes issue #382 
