### PR TITLE
make njs successfully build

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -304,6 +304,12 @@ class NginxFull < Formula
       system "./configure", *args
     end
 
+    if build.with?("njs-module")
+      # nginx Makefile tries to clean and build njs module again
+      # we remove the lines responsible for the problem
+      system "sed", "-e", '\/opt\/homebrew\/share\/njs-nginx-module\/nginx\/..\/build\/libnjs.a:/,+4d', "-i", "''", "objs/Makefile"
+    end
+
     system "make", "install"
     if build.head?
       man8.install "docs/man/nginx.8"

--- a/Formula/njs-nginx-module.rb
+++ b/Formula/njs-nginx-module.rb
@@ -1,8 +1,8 @@
 class NjsNginxModule < Formula
   desc "Adds support for njs scripting to nginx"
   homepage "https://github.com/nginx/njs"
-  url "https://github.com/nginx/njs/archive/0.7.1.tar.gz"
-  sha256 "f5493b444ef54f1edba85c7adcbb1132e61c36d47de8f7a8d351965cad6d5486"
+  url "https://github.com/nginx/njs/archive/0.7.7.tar.gz"
+  sha256 "f9e5b6ee79711ef2fcea6482144c0c901b99ba6bd52d72c1c0ae7415a42f4f45"
   head "https://github.com/nginx/njs.git", branch: "master"
 
   depends_on "pcre" => :build


### PR DESCRIPTION
nasty hack but fixes issue #408 by modifying the Makefile to not attempt to make-clean and rebuild njs again.