### PR TITLE
Replace modern service definition.

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -379,31 +379,13 @@ class NginxFull < Formula
     s
   end
 
-  plist_options manual: "nginx"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>KeepAlive</key>
-          <false/>
-          <key>ProgramArguments</key>
-          <array>
-              <string>#{opt_bin}/nginx</string>
-              <string>-g</string>
-              <string>daemon off;</string>
-          </array>
-          <key>WorkingDirectory</key>
-          <string>#{HOMEBREW_PREFIX}</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"nginx", "-g", "daemon off;"]
+    working_dir HOMEBREW_PREFIX
+    keep_alive true
+    require_root true
+    log_path var/"log/nginx.log"
+    error_log_path var/"log/nginx-error.log"
   end
 
   test do


### PR DESCRIPTION
This resolves #420 <!-- kek --> by supplying a modern service definition equivalent to the launchd `plist` previously supplied.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/denji/homebrew-nginx/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/denji/homebrew-nginx/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) ~~and corrected all errors~~? [Issues present were pre-existing.]
- [x] Built your formula locally prior to submission with `brew install <formula>`? [And confirmed through local service startup and use.]
- [x] ~Removed the `revision` line, if any, when bumping the version number?~
- [x] ~Added/bumped the `revision` number if the changes affect the precompiled bottles?~
- [x] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?

Tests not examined; I had a number of issues installing a few of my desired modules which were difficult to pin down, or I just disabled that option and moved on…