### PR TITLE
Replace plist def with service def

### DIFF
--- a/Formula/openresty-debug.rb
+++ b/Formula/openresty-debug.rb
@@ -4,7 +4,7 @@ class OpenrestyDebug < Formula
   VERSION = "1.15.8.3".freeze
   url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
   sha256 "b68cf3aa7878db16771c96d9af9887ce11f3e96a1e5e68755637ecaff75134a8"
-  revision 1
+  revision 2
 
   option "with-postgresql", "Compile with ngx_http_postgres_module"
   option "with-iconv", "Compile with ngx_http_iconv_module"
@@ -77,31 +77,10 @@ class OpenrestyDebug < Formula
     system "make", "install"
   end
 
-  plist_options manual: "openresty"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>KeepAlive</key>
-          <false/>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_prefix}/bin/openresty</string>
-            <string>-g</string>
-            <string>daemon off;</string>
-          </array>
-          <key>WorkingDirectory</key>
-          <string>#{HOMEBREW_PREFIX}</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"openresty", "-g", "daemon off;"]
+    working_dir HOMEBREW_PREFIX
+    keep_alive false
   end
 
   test do

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -4,7 +4,7 @@ class Openresty < Formula
   VERSION = "1.15.8.3".freeze
   url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
   sha256 "b68cf3aa7878db16771c96d9af9887ce11f3e96a1e5e68755637ecaff75134a8"
-  revision 1
+  revision 2
 
   option "with-debug", "Compile with support for debug logging"
   option "with-postgresql", "Compile with ngx_http_postgres_module"
@@ -78,31 +78,10 @@ class Openresty < Formula
     system "make", "install"
   end
 
-  plist_options manual: "openresty"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>KeepAlive</key>
-          <false/>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_prefix}/bin/openresty</string>
-            <string>-g</string>
-            <string>daemon off;</string>
-          </array>
-          <key>WorkingDirectory</key>
-          <string>#{HOMEBREW_PREFIX}</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"openresty", "-g", "daemon off;"]
+    working_dir HOMEBREW_PREFIX
+    keep_alive false
   end
 
   test do


### PR DESCRIPTION
A line by line adaption of the old plist def into service block def.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/denji/homebrew-nginx/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/denji/homebrew-nginx/pulls) for the same update/change?
- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [x] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?

related

- https://github.com/denji/homebrew-nginx/pull/421
