### PR TITLE
✨ feat: add nginx_upstream_check_module to replace the previous health check module

### DIFF
--- a/Formula/nginx_upstream_check_module.rb
+++ b/Formula/nginx_upstream_check_module.rb
@@ -1,0 +1,11 @@
+class UpstreamcheckNginxModule < Formula
+  desc "Health checks upstreams for nginx"
+  homepage "https://github.com/yaoweibin/nginx_upstream_check_module"
+  url "https://github.com/yaoweibin/nginx_upstream_check_module/archive/refs/tags/v0.4.0.tar.gz"
+  version "0.4.0"
+  sha256 "41059b5a703ccc45cd404b345e5a77c6d6bc92f6b5d41865a9a6ce92291cd57b"
+
+  def install
+    pkgshare.install Dir["*"]
+  end
+end


### PR DESCRIPTION
…hcheck_nginx_upstreams

- add a new module, nginx_upstream_check_module to replace healthcheck-nginx-module. cuz healthcheck-nginx-module is not maintained by the owner any more.
- It can resolve the issue #263 by using new module.