### PR TITLE
feat: format the name and support it in nginx-full

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -104,6 +104,7 @@ class NginxFull < Formula
       "mruby"               => "Build with MRuby support",
       "naxsi"               => "Build with Naxsi support",
       "nchan"               => "Build with Nchan support",
+      "nginx-upstream-check"=> "Build with new healthcheck support",
       "njs"                 => "Build with njs support",
       "notice"              => "Build with HTTP Notice support",
       "php-session"         => "Build with Parse PHP Sessions support",

--- a/Formula/nginx-upstream-check-module.rb
+++ b/Formula/nginx-upstream-check-module.rb
@@ -1,5 +1,5 @@
 class UpstreamcheckNginxModule < Formula
-  desc "Health checks upstreams for nginx"
+  desc "new health checks upstreams for nginx"
   homepage "https://github.com/yaoweibin/nginx_upstream_check_module"
   url "https://github.com/yaoweibin/nginx_upstream_check_module/archive/refs/tags/v0.4.0.tar.gz"
   version "0.4.0"

--- a/Formula/nginx_upstream_check_module.rb
+++ b/Formula/nginx_upstream_check_module.rb
@@ -1,0 +1,11 @@
+class UpstreamcheckNginxModule < Formula
+  desc "Health checks upstreams for nginx"
+  homepage "https://github.com/yaoweibin/nginx_upstream_check_module"
+  url "https://github.com/yaoweibin/nginx_upstream_check_module/archive/refs/tags/v0.4.0.tar.gz"
+  version "0.4.0"
+  sha256 "41059b5a703ccc45cd404b345e5a77c6d6bc92f6b5d41865a9a6ce92291cd57b"
+
+  def install
+    pkgshare.install Dir["*"]
+  end
+end


### PR DESCRIPTION
- format the name from nginx_upstream_check_module  to nginx-upstream-check-module to keep the same style
- add the new module defined in nginx-full.rb, mentioned under the comment of #425 